### PR TITLE
Enhance File Selection by Using Last File's Directory as Starting Point

### DIFF
--- a/src/main/kotlin/com/jaspervanmerle/cglocal/controller/ConnectedController.kt
+++ b/src/main/kotlin/com/jaspervanmerle/cglocal/controller/ConnectedController.kt
@@ -82,7 +82,8 @@ class ConnectedController {
     }
 
     fun selectFile() {
-        val fileChooser = JFileChooser().apply {
+        val startDirectory = if (selectedFile.exists()) selectedFile.parent else System.getProperty("user.home")
+        val fileChooser = JFileChooser(startDirectory).apply {
             dialogTitle = "Select a file"
         }
 


### PR DESCRIPTION
This PR makes selecting files in `ConnectedController` a bit more user-friendly when you're doing a bunch of challenges back-to-back.

Now, if you've picked a file before, it'll start in the same folder. This way, you don't have to keep navigating from scratch every time.

**Key Changes:**
- `selectFile` checks if the last file picked exists. If it does, it uses its folder as the starting point. If not, it switches to using home directory as a fallback.

**Benefits:**
- Reduces unnecessary navigation by selecting the starting directory based on the user's recent activity.
- Ensures a reliable fallback to the user's home directory.

**Thought for Later:**
It might be neat to let you set a default start folder in the settings later on, rather than just use the user's home directory. This could be a nice touch for tailoring the app to fit your workflow from the very first challenge.

Looking forward to your thoughts!